### PR TITLE
Add Scala 2.13 flags

### DIFF
--- a/src/main/scala/buildo/ScalaSettingPlugin.scala
+++ b/src/main/scala/buildo/ScalaSettingPlugin.scala
@@ -16,8 +16,9 @@ object ScalaSettingPlugin extends AutoPlugin {
 
   def crossFlags(scalaVersion: String): Seq[String] =
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, 11)) => Seq("-Yinline-warnings")
-      case Some((2, 12)) => Seq("-opt-warnings")
+      case Some((2, 11)) => Seq("-Yinline-warnings", "-Ypartial-unification")
+      case Some((2, 12)) => Seq("-opt-warnings", "-Ypartial-unification")
+      case Some((2, 13)) => Seq("-Ymacro-annotations")
       case _ => Nil
     }
 
@@ -35,7 +36,6 @@ object ScalaSettingPlugin extends AutoPlugin {
       "-Ywarn-unused",
       "-Ywarn-unused-import",
       "-Yrangepos",
-      "-Ypartial-unification"
     ) ++ crossFlags(scalaVersion.value),
     resolvers += Resolver.jcenterRepo
   )

--- a/src/main/scala/buildo/ScalaSettingPlugin.scala
+++ b/src/main/scala/buildo/ScalaSettingPlugin.scala
@@ -16,8 +16,8 @@ object ScalaSettingPlugin extends AutoPlugin {
 
   def crossFlags(scalaVersion: String): Seq[String] =
     CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, 11)) => Seq("-Yinline-warnings", "-Ypartial-unification")
-      case Some((2, 12)) => Seq("-opt-warnings", "-Ypartial-unification")
+      case Some((2, 11)) => Seq("-Yinline-warnings", "-Ypartial-unification", "-Xfuture")
+      case Some((2, 12)) => Seq("-opt-warnings", "-Ypartial-unification", "-Xfuture")
       case Some((2, 13)) => Seq("-Ymacro-annotations")
       case _ => Nil
     }
@@ -26,10 +26,12 @@ object ScalaSettingPlugin extends AutoPlugin {
     cancelable in Global := true,
     scalacOptions ++= Seq(
       "-encoding", "utf8",
-      "-deprecation", "-feature", "-unchecked", "-Xlint",
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      "-Xlint",
       "-language:higherKinds",
       "-language:implicitConversions",
-      "-Xfuture",
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-value-discard",


### PR DESCRIPTION
- add `-Ymacro-annotations` for 2.13 only (it replaces the macroparadise plugin)
- enable `-Ypartial-unification` for < 2.13 only (it's the default in 2.13)
- enable `-Xfuture` for < 2.13 only (it's deprecated in 2.13)